### PR TITLE
Interfaces for all parsers

### DIFF
--- a/src/rfc_fstar_compiler.ml
+++ b/src/rfc_fstar_compiler.ml
@@ -732,7 +732,7 @@ and compile_select o i n tagn tagt taga cl def al =
   (* FIXME(adl) can't prove by normalization because of opaque kinds in interfaces *)
   let same_kind = match def with
     | None -> sprintf "  assert_norm (LP.parse_sum_kind (LP.get_parser_kind %s_repr_parser) %s_sum parse_%s_cases == %s_parser_kind);\n" tn n n n
-    | Some dt -> sprintf "  assert_norm (LP.parse_dsum_kind (LP.get_parser_kind %s_repr_parser) %s_sum parse_%s_cases %s_parser_kind == %s_parser_kind);\n" tn n n (compile_type dt) n
+    | Some dt -> sprintf "  assert_norm (LP.parse_dsum_kind (LP.get_parser_kind %s_repr_parser) %s_sum parse_%s_cases (LP.get_parser_kind %s) == %s_parser_kind);\n" tn n n (pcombinator_name (compile_type dt)) n
     in
 
   let annot = if is_private then " : LP.parser "^n^"_parser_kind "^n else "" in

--- a/tests/unittests.rfc
+++ b/tests/unittests.rfc
@@ -48,7 +48,7 @@ struct {
 } t9;
 
 struct {
-  t3 essai;
+  t3 simplify;
 } t10;
 
 struct {
@@ -64,29 +64,32 @@ struct {
 struct {
   uint8 u;
   opaque x<0..255>;
+  uint16 y;
 } t13;
 
 struct {
   uint8 u;
   opaque x[18]; 
+  uint16 y;
 } t14;
 
 struct {
-  uint8 u;
-  t3 z<0..255>;
+  t1 start;
+  tag2 t;
+  select(t) {
+    case x: uint16;
+    case y: uint32;
+    case w: Empty;
+    default: Fail;
+  } body;
 } t15;
 
 struct {
-  uint8 u;
-  t3 z[18];
+  uint16 len;
+  tag t;
+  select(t)
+  {
+    case a: Empty;
+    case b: t13;
+  } x;
 } t16;
-
-struct {
-  uint8 u;
-  uint16 z<0..255>;
-} t17;
-
-struct {
-  uint8 u;
-  uint16 z[18];
-} t18;


### PR DESCRIPTION
When constructed types require internal parser definitions, write them to separate modules (with interfaces). This should improve verification for complex types with many inline definitions.